### PR TITLE
Get keyboard shortcut working even if extension's button is hidden.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,9 @@
 
   "commands": {
     "_execute_browser_action": {
+      "description": "Toggle presentation mode."
+    },
+    "toggle": {
       "suggested_key": {
         "default": "Ctrl+Shift+F",
         "mac": "MacCtrl+Shift+F"

--- a/presentation-mode.js
+++ b/presentation-mode.js
@@ -1,6 +1,6 @@
 "use strict";
 
-chrome.browserAction.onClicked.addListener(function () {
+function toggle() {
   chrome.windows.getCurrent(function (window) {
     if (window.state === "fullscreen") {
       chrome.windows.update(window.id, { state: "normal" });
@@ -8,4 +8,7 @@ chrome.browserAction.onClicked.addListener(function () {
       chrome.windows.update(window.id, { state: "fullscreen" });
     }
   });
-});
+}
+
+chrome.commands.onCommand.addListener(toggle);
+chrome.browserAction.onClicked.addListener(toggle);


### PR DESCRIPTION
Master has a mildly annoying issue: If you hide the extension's button, the keyboard shortcut no longer works.

I'm not entirely sure why this is the case. It looks like Chrome doesn't fire off the browser action if the button is hidden. Since Chrome's extension API doesn't let you bind to special commands like `_execute_browser_action`, I created a `toggle` command and set the keyboard shortcuts on it. Behavior should be the same as before, except that there are now two keyboard shortcut inputs at the bottom of `chrome://extensions`:

<img width="500" alt="screen shot 2015-08-24 at 22 11 21" src="https://cloud.githubusercontent.com/assets/200121/9459162/1d8fb92e-4aad-11e5-953d-ee630f210ab4.png">

I'm not sure how to hide the first one. Also, the code could be slightly cleaned up by having `chrome.commands.onCommand.addListener()` check the command name.

I have very little experience with Chrome extension development. I'm just trying to get presentation mode back. :cry: So if you have suggestions on how to improve this PR, I'm all ears.
